### PR TITLE
Update the apt key

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: import aptly repo key
   sudo: yes
-  apt_key: id=E083A3782A194991 keyserver=keys.gnupg.net state=present
+  apt_key: id=9E3E53F19C7DE460 keyserver=keys.gnupg.net state=present
 
 - name: add aptly debian repository
   sudo: yes


### PR DESCRIPTION
It looks like the apt key changed. I had been getting:

```
TASK [aptly : install required packages] ***************************************
failed: [localhost] (item=[u'gnupg2', u'rng-tools', u'aptly']) => ...WARNING: The following packages cannot be authenticated!\n  aptly\n"...
```

and then I saw that http://repo.aptly.info/ says that the key is `9E3E53F19C7DE460`.