### PR TITLE
Account for no ansible_ssh_user in Ansible 2.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,5 @@
 ---
 # defaults file for aptly
+
+# The |default... stuff is because `ansible_ssh_user` doesn't work in Ansible 2.0
+aptly_gpg_key_dir: "{{ lookup('env', 'HOME') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,16 +21,16 @@
 
 - name: start rngd for entropy creation
   sudo: true
-  command: rngd -b -r /dev/urandom creates=/home/{{ ansible_ssh_user }}/key.sec
+  command: rngd -b -r /dev/urandom creates={{ aptly_gpg_key_dir }}/key.sec
 
 - name: copy gpg key-gen batch file
   template:
     src: gpg2_gen_key.j2
-    dest: /home/{{ ansible_ssh_user }}/gpg2_gen_key
+    dest: "{{ aptly_gpg_key_dir }}/gpg2_gen_key"
     mode: 0644
 
 - name: create key
-  command: gpg --batch --gen-key /home/{{ ansible_ssh_user }}/gpg2_gen_key creates=/home/{{ ansible_ssh_user }}/key.sec
+  command: gpg --batch --gen-key {{ aptly_gpg_key_dir }}/gpg2_gen_key creates={{ aptly_gpg_key_dir }}/key.sec
 
 - name: stop random source
   service:
@@ -38,11 +38,11 @@
     state: stopped
 
 - name: import pub key to gnupg
-  command: gpg2 --import /home/{{ ansible_ssh_user }}/key.pub
+  command: gpg2 --import {{ aptly_gpg_key_dir }}/key.pub
 
 # ignore 'already in secret keyring' error
 - name: import sec key to gnupg
-  command: gpg2 --import /home/{{ ansible_ssh_user }}/key.sec
+  command: gpg2 --import {{ aptly_gpg_key_dir }}/key.sec
   ignore_errors: yes
 
 # end key creation tasks

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -10,11 +10,11 @@
 
 - name: copy dummy package
   sudo: yes
-  copy: src=dummy_0.1_all.deb dest=/home/{{ ansible_ssh_user }}
+  copy: src=dummy_0.1_all.deb dest=/tmp
 
 - name: upload dummy package to server
   command: >
-    curl -X POST -F file=@dummy_0.1_all.deb http://localhost:8080/api/files/dummy
+    curl -X POST -F file=@/tmp/dummy_0.1_all.deb http://localhost:8080/api/files/dummy
 
 - name: add dummy package to repository
   command: >

--- a/templates/gpg2_gen_key.j2
+++ b/templates/gpg2_gen_key.j2
@@ -5,8 +5,8 @@ Name-Real: {{ aptly_company_name }}
 Name-Comment: aptly key no passphrase
 Name-Email: {{ aptly_key_email }}
 Expire-Date: 0
-%pubring key.pub
-%secring key.sec
+%pubring {{ aptly_gpg_key_dir }}/key.pub
+%secring {{ aptly_gpg_key_dir }}/key.sec
 # Do a commit here, so that we can later print "done" :-)
 %commit
 %echo done


### PR DESCRIPTION
Otherwise, I get errors like this with Ansible 2.0.2.0:

```
TASK [aptly : start rngd for entropy creation] *********************************
fatal: [localhost]: FAILED! => {"failed": true, "msg": "'ansible_ssh_user' is undefined"}
```